### PR TITLE
1.17 Compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,13 +31,13 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <version>1.17-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.github.bananapuncher714</groupId>
             <artifactId>nbteditor</artifactId>
-            <version>7.16.1</version>
+            <version>7.17.0</version>
         </dependency>
     </dependencies>
     <build>
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.4</version>
                 <configuration>
                     <relocations>
                         <relocation>

--- a/src/main/java/me/darrionat/serverselector/listeners/PlayerJoin.java
+++ b/src/main/java/me/darrionat/serverselector/listeners/PlayerJoin.java
@@ -38,9 +38,11 @@ public class PlayerJoin implements Listener {
 
         // Handle updating the selector in the player's inventory if it has changed in the config
         ListIterator<ItemStack> iterator = p.getInventory().iterator();
-        while (iterator.hasNext())
-            if (itemService.isServerSelector(iterator.next()))
-                iterator.remove();
+        while (iterator.hasNext()) {
+            final ItemStack item = iterator.next();
+            if (itemService.isServerSelector(item))
+                p.getInventory().removeItem(item);
+        }
         itemService.giveSelectorToPlayer(p);
     }
 }

--- a/src/main/java/me/darrionat/serverselector/services/ItemService.java
+++ b/src/main/java/me/darrionat/serverselector/services/ItemService.java
@@ -18,6 +18,7 @@ public class ItemService implements IItemService {
     }
 
     public boolean isServerSelector(ItemStack item) {
+        if (item == null) return false;
         return NBTEditor.contains(item, KEY);
     }
 


### PR DESCRIPTION
There were errors in console when a player joins. I changed the API calls we use to remove an item and check if the server selector is already in the inventory. I haven't tested it in any earlier versions.